### PR TITLE
ci: enforce dist artifact upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,21 +21,26 @@ jobs:
       - run: flutter pub get
       - run: flutter build appbundle --release --target-platform=android-arm64
       - run: flutter build apk --release --target-platform=android-arm64 --split-per-abi
-      - name: Package android arm64 artifacts
+      - name: Collect android arm64 artifacts
         run: |
           set -euxo pipefail
-          mkdir -p build/artifacts
+          mkdir -p dist/android-arm64
           AAB=$(ls -1 build/app/outputs/bundle/release/*.aab | head -n1)
-          APK=$(ls -1 build/app/outputs/flutter-apk/*arm64-v8a*.apk | head -n1)
-          cp "$AAB" build/artifacts/
-          cp "$APK" build/artifacts/
-          (cd build/artifacts && zip -9 -r ../android-arm64.zip .)
-      - uses: actions/upload-artifact@v4
+          cp "$AAB" dist/android-arm64/
+          APKS=$(find build/app/outputs/flutter-apk -maxdepth 1 -type f -name '*arm64*.apk')
+          if [ -z "$APKS" ]; then
+            echo "No arm64 APK produced" >&2
+            exit 1
+          fi
+          while IFS= read -r APK; do
+            cp "$APK" dist/android-arm64/
+          done <<< "$APKS"
+      - name: Upload android dist artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: android-arm64
-          path: build/android-arm64.zip
+          name: dist-android-arm64
+          path: dist/android-arm64/**
           if-no-files-found: error
-          retention-days: 90
 
   linux-amd64:
     runs-on: ubuntu-latest
@@ -49,13 +54,17 @@ jobs:
       - run: flutter config --enable-linux-desktop
       - run: flutter pub get
       - run: flutter build linux --release
-      - run: tar -C build/linux/x64/release/bundle -czf build/app-linux-amd64.tar.gz .
-      - uses: actions/upload-artifact@v4
+      - name: Package linux amd64 artifacts
+        run: |
+          set -euxo pipefail
+          mkdir -p dist/linux-amd64
+          tar -C build/linux/x64/release/bundle -czf dist/linux-amd64/app-linux-amd64.tar.gz .
+      - name: Upload linux dist artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: linux-amd64
-          path: build/app-linux-amd64.tar.gz
+          name: dist-linux-amd64
+          path: dist/linux-amd64/**
           if-no-files-found: error
-          retention-days: 90
 
   windows-amd64:
     runs-on: windows-latest
@@ -68,16 +77,22 @@ jobs:
       - run: flutter config --enable-windows-desktop
       - run: flutter pub get
       - run: flutter build windows --release
-      - shell: pwsh
+      - name: Package windows amd64 artifacts
+        shell: pwsh
         run: |
-          cd build/windows/x64/runner/Release
-          Compress-Archive -Path * -DestinationPath ../../../app-windows-amd64.zip
-      - uses: actions/upload-artifact@v4
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $source = "build/windows/x64/runner/Release"
+          if (!(Test-Path $source)) { throw "Missing Windows release directory: $source" }
+          Compress-Archive -Path "$source/*" -DestinationPath "build/app-windows-amd64.zip" -Force
+          New-Item -ItemType Directory -Path "dist/windows-amd64" -Force | Out-Null
+          Move-Item "build/app-windows-amd64.zip" "dist/windows-amd64/app-windows-amd64.zip" -Force
+      - name: Upload windows dist artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: windows-amd64
-          path: build/app-windows-amd64.zip
+          name: dist-windows-amd64
+          path: dist/windows-amd64/**
           if-no-files-found: error
-          retention-days: 90
 
   macos-arm64:
     runs-on: macos-14  # Apple Silicon runner to produce arm64 binaries
@@ -90,17 +105,64 @@ jobs:
       - run: flutter config --enable-macos-desktop
       - run: flutter pub get
       - run: flutter build macos --release
-      - run: |
+      - name: Package macOS arm64 artifacts
+        run: |
+          set -euxo pipefail
           APP_PATH=$(ls -1 build/macos/Build/Products/Release/*.app | head -n1)
           APP_NAME=$(basename "$APP_PATH" .app)
-          DMG="build/${APP_NAME}-macos-arm64.dmg"
-          mkdir -p build/dmgroot
+          mkdir -p build/dmgroot dist/macos-arm64
           cp -R "$APP_PATH" build/dmgroot/
           ln -s /Applications build/dmgroot/Applications || true
+          DMG="dist/macos-arm64/${APP_NAME}-macos-arm64.dmg"
           hdiutil create -volname "$APP_NAME" -srcfolder build/dmgroot -ov -format UDZO "$DMG"
-      - uses: actions/upload-artifact@v4
+      - name: Upload macOS dist artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: macos-arm64
-          path: build/*-macos-arm64.dmg
+          name: dist-macos-arm64
+          path: dist/macos-arm64/**
           if-no-files-found: error
-          retention-days: 90
+
+  collect-artifacts:
+    runs-on: ubuntu-latest
+    needs:
+      - android-arm64
+      - linux-amd64
+      - windows-amd64
+      - macos-arm64
+    steps:
+      - name: Download android dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-android-arm64
+          path: .
+      - name: Download linux dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-linux-amd64
+          path: .
+      - name: Download windows dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-windows-amd64
+          path: .
+      - name: Download macOS dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-macos-arm64
+          path: .
+      - name: List collected dist contents
+        run: |
+          set -euxo pipefail
+          echo "::group::DIST-LIST"
+          if [ ! -d dist ]; then
+            echo "dist directory missing after downloads" >&2
+            exit 1
+          fi
+          ls -lR dist
+          echo "::endgroup::"
+      - name: Upload consolidated build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: dist/**
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Update CI build pipeline to collect cross-platform artifacts under `dist/` and publish a consolidated bundle.
+
 ## v0.8.80
 
 - Optimize dashboard performance


### PR DESCRIPTION
## Summary
- collect each platform's build output under dist/<platform>
- stage per-platform dist directories as intermediate artifacts
- add consolidation job that publishes build-artifacts with a DIST-LIST log group

## Testing
- not run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68caecacae4c8326bd4a0c54a379dcc3